### PR TITLE
Fixes 'titles' typo in app.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -65,7 +65,7 @@ app.post("/", bodyParser, (req, res) => {
           excerpt: parsed.excerpt || "",
           byline: parsed.byline || "",
           length: parsed.length,
-          title: parsed.titles || "",
+          title: parsed.title || "",
         })
         .end();
     })


### PR DESCRIPTION
This made titles work for me